### PR TITLE
Remove network interface id from outputs

### DIFF
--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -58,10 +58,6 @@ output "instance_key_name" {
   value = "${module.session_manager.instance_key_name}"
 }
 
-output "instance_network_interface_id" {
-  value = "${module.session_manager.instance_network_interface_id}"
-}
-
 output "instance_primary_network_interface_id" {
   value = "${module.session_manager.instance_primary_network_interface_id}"
 }

--- a/examples/minimal/outputs.tf
+++ b/examples/minimal/outputs.tf
@@ -58,10 +58,6 @@ output "instance_key_name" {
   value = "${module.session_manager.instance_key_name}"
 }
 
-output "instance_network_interface_id" {
-  value = "${module.session_manager.instance_network_interface_id}"
-}
-
 output "instance_primary_network_interface_id" {
   value = "${module.session_manager.instance_primary_network_interface_id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -73,11 +73,6 @@ output "instance_key_name" {
   description = "The key name of the instance."
 }
 
-output "instance_network_interface_id" {
-  value       = "${aws_instance.default.network_interface_id}"
-  description = "The ID of the network interface that was created with the instance."
-}
-
 output "instance_primary_network_interface_id" {
   value       = "${aws_instance.default.primary_network_interface_id}"
   description = "The ID of the instance's primary network interface."


### PR DESCRIPTION
Add support for terraform-provider-aws 2.0.0

- BREAKING CHANGES
    - resource/aws_instance: Remove deprecated top-level network_interface_id attribute
    - https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#200-february-27-2019